### PR TITLE
LogicalTypes - a few codegen scenarios to discuss

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/avro/logicalTypesTest1.avsc
+++ b/fastserde/avro-fastserde-tests-common/src/test/avro/logicalTypesTest1.avsc
@@ -1,0 +1,81 @@
+{
+  "type": "record",
+  "name": "FastSerdeLogicalTypesTest1",
+  "namespace": "com.linkedin.avro.fastserde.generated.avro",
+  "doc": "Used in tests to confirm fast-serde supports logical-types",
+  "fields": [
+    {
+      "name": "decimalOrDateUnion",
+      "type": [
+        {
+          "type": "bytes",
+          "logicalType": "decimal",
+          "precision": 4,
+          "scale": 2
+        },
+        {
+          "type": "int",
+          "logicalType": "date"
+        }
+      ]
+    },
+    {
+      "name": "uuidField",
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
+    },
+    {
+      "name": "timestampMillisField",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      }
+    },
+    {
+      "name": "timestampMicrosField",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-micros"
+      }
+    },
+    {
+      "name": "timeMillisField",
+      "type": {
+        "type": "int",
+        "logicalType": "time-millis"
+      }
+    },
+    {
+      "name": "timeMicrosField",
+      "type": {
+        "type": "long",
+        "logicalType": "time-micros"
+      }
+    },
+    {
+      "name": "dateField",
+      "type": {
+        "type": "int",
+        "logicalType": "date"
+      }
+    },
+    {
+      "name": "nestedLocalTimestampMillis",
+      "type": {
+        "name": "LocalTimestampRecord",
+        "type": "record",
+        "fields": [
+          {
+            "name": "nestedTimestamp",
+            "type": {
+              "type": "long",
+              "logicalType": "local-timestamp-millis"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/fastserde/avro-fastserde-tests18/build.gradle
+++ b/fastserde/avro-fastserde-tests18/build.gradle
@@ -30,6 +30,7 @@ dependencies {
   testImplementation "org.slf4j:slf4j-api:1.7.14"
   testImplementation "org.apache.commons:commons-lang3:3.4"
   testImplementation "com.sun.codemodel:codemodel:2.6"
+  implementation "joda-time:joda-time:2.12.5"
 
   testImplementation ("org.apache.avro:avro:1.8.2") {
     exclude group: "org.slf4j"


### PR DESCRIPTION
1. `avro 1.9` generates fields
```
   private java.time.Instant timestampMicrosField;
   private java.time.LocalTime timeMicrosField;
```
but no conversion to/from micros is specified
```
  private static SpecificData MODEL$ = new SpecificData();
static {
    MODEL$.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.DateConversion());
    MODEL$.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMillisConversion());
    MODEL$.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMillisConversion());
  }
```

2. Only `1.11.1` generates
```
  private java.util.UUID uuidField;
```
instead of `private java.lang.CharSequence uuidField;`
Versions `1.9+` have UUID in `org.apache.avro.LogicalTypes`.

3. Only `1.10+` adds decimal conversion
```
MODEL$.addLogicalTypeConversion(new org.apache.avro.Conversions.DecimalConversion());
```